### PR TITLE
Add LoRa support

### DIFF
--- a/ac-local-plugin/code/LocalLlama.cpp
+++ b/ac-local-plugin/code/LocalLlama.cpp
@@ -26,6 +26,8 @@
 
 namespace ac::local {
 
+llama::ModelRegistry g_modelRegistry;
+
 namespace {
 class ChatSession {
     llama::Session m_session;
@@ -236,7 +238,7 @@ class LlamaModel final : public Model {
 public:
 
     LlamaModel(const std::string& gguf, std::vector<llama::ControlVector::LoadInfo>& ctrlVectors, llama::ModelLoadProgressCb pcb, llama::Model::Params params)
-        : m_model(std::make_shared<llama::Model>(gguf.c_str(), astl::move(pcb), astl::move(params)))
+        : m_model(std::make_shared<llama::Model>(g_modelRegistry.loadModel(gguf.c_str(), {}, astl::move(pcb), astl::move(params))))
         , m_ctrlVectors(astl::move(ctrlVectors))
     {}
 

--- a/ac-local-plugin/code/LocalLlama.cpp
+++ b/ac-local-plugin/code/LocalLlama.cpp
@@ -26,8 +26,6 @@
 
 namespace ac::local {
 
-llama::ModelRegistry g_modelRegistry;
-
 namespace {
 class ChatSession {
     llama::Session m_session;
@@ -238,7 +236,7 @@ class LlamaModel final : public Model {
 public:
 
     LlamaModel(const std::string& gguf, std::vector<llama::ControlVector::LoadInfo>& ctrlVectors, llama::ModelLoadProgressCb pcb, llama::Model::Params params)
-        : m_model(std::make_shared<llama::Model>(g_modelRegistry.loadModel(gguf.c_str(), {}, astl::move(pcb), astl::move(params))))
+        : m_model(std::make_shared<llama::Model>(llama::Model(gguf.c_str(), {}, astl::move(pcb), astl::move(params))))
         , m_ctrlVectors(astl::move(ctrlVectors))
     {}
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -34,4 +34,6 @@ target_sources(ac-llama PRIVATE
     ac/llama/IncrementalStringFinder.cpp
     ac/llama/ControlVector.hpp
     ac/llama/ControlVector.cpp
+    ac/llama/LoraAdapter.hpp
+    ac/llama/LoraAdapter.cpp
 )

--- a/code/ac/llama/Instance.cpp
+++ b/code/ac/llama/Instance.cpp
@@ -21,7 +21,7 @@
 namespace ac::llama {
 
 namespace {
-llama_context_params llamaFromInstanceInitParams(Model& model, const Instance::InitParams& params) {
+llama_context_params llamaFromInstanceInitParams(const Instance::InitParams& params) {
     llama_context_params llamaParams = llama_context_default_params();
     llamaParams.n_ctx = params.ctxSize;
     llamaParams.n_batch = params.batchSize;
@@ -34,7 +34,7 @@ llama_context_params llamaFromInstanceInitParams(Model& model, const Instance::I
 Instance::Instance(Model& model, InitParams params)
     : m_model(model)
     , m_sampler(model, {})
-    , m_lctx(llama_new_context_with_model(model.lmodel(), llamaFromInstanceInitParams(model, params)), llama_free)
+    , m_lctx(llama_new_context_with_model(model.lmodel(), llamaFromInstanceInitParams(params)), llama_free)
 {
     if (!m_lctx) {
         throw_ex{} << "Failed to create llama context";

--- a/code/ac/llama/Instance.cpp
+++ b/code/ac/llama/Instance.cpp
@@ -47,19 +47,10 @@ Instance::Instance(Model& model, InitParams params)
         LLAMA_LOG(Warning, "Instance requested context length ", ctxLen, " is greater than the model's training context length ", ctxTrain);
     }
 
-    for (auto& loraConfig : params.loraConfigs) {
-        if (loraConfig.scale == 0.0f) {
-            continue;
-        }
-
-        llama_lora_adapter* adapter = llama_lora_adapter_init(m_model.lmodel(), loraConfig.path.c_str());
-        if (!adapter) {
-            LLAMA_LOG(Error, "Failed to initialize LORA adapter from ", loraConfig.path);
-            continue;
-        }
-
-        if (llama_lora_adapter_set(m_lctx.get(), adapter, loraConfig.scale) < 0) {
-            LLAMA_LOG(Error, "Failed to set LORA adapter from ", loraConfig.path);
+    for (auto& lora: model.loras())
+    {
+        if (llama_lora_adapter_set(m_lctx.get(), lora->adapter(), lora->scale()) < 0) {
+            LLAMA_LOG(Error, "Failed to set LORA adapter from ", lora->path());
         }
     }
 }

--- a/code/ac/llama/Instance.cpp
+++ b/code/ac/llama/Instance.cpp
@@ -3,6 +3,7 @@
 //
 #include "Instance.hpp"
 #include "Model.hpp"
+#include "LoraAdapter.hpp"
 #include "Logging.hpp"
 #include "Session.hpp"
 #include "ControlVector.hpp"

--- a/code/ac/llama/Instance.hpp
+++ b/code/ac/llama/Instance.hpp
@@ -20,6 +20,13 @@ public:
         uint32_t ctxSize = 0; // context size for the model (0 = maximum allowed by model)
         uint32_t batchSize = 2048; // logical batch size for prompt processing (may be silently truncated to ctxSize)
         uint32_t ubatchSize = 512; // physical batch size for prompt processing (0 = batchSize)
+        bool flashAttn = false; // enable flash attention
+
+        struct LoraConfig {
+            std::string path;
+            float scale = 1.0f;
+        };
+        std::vector<LoraConfig> loraConfigs; // LORA adapters to apply
     };
 
     explicit Instance(Model& model, InitParams params);

--- a/code/ac/llama/Instance.hpp
+++ b/code/ac/llama/Instance.hpp
@@ -21,12 +21,6 @@ public:
         uint32_t batchSize = 2048; // logical batch size for prompt processing (may be silently truncated to ctxSize)
         uint32_t ubatchSize = 512; // physical batch size for prompt processing (0 = batchSize)
         bool flashAttn = false; // enable flash attention
-
-        struct LoraConfig {
-            std::string path;
-            float scale = 1.0f;
-        };
-        std::vector<LoraConfig> loraConfigs; // LORA adapters to apply
     };
 
     explicit Instance(Model& model, InitParams params);

--- a/code/ac/llama/LoraAdapter.cpp
+++ b/code/ac/llama/LoraAdapter.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) Alpaca Core
+// SPDX-License-Identifier: MIT
+//
+#include "LoraAdapter.hpp"
+#include "Model.hpp"
+
+#include <llama.h>
+
+namespace ac::llama {
+
+LoraAdapter::LoraAdapter(Model& model, std::string path, float scale)
+    : m_adapter(llama_lora_adapter_init(model.lmodel(), path.c_str()), llama_lora_adapter_free)
+    , m_scale(scale)
+    , m_path(std::move(path))
+{
+    if (!m_adapter) {
+        throw std::runtime_error("Failed to initialize LORA adapter from " + m_path);
+    }
+}
+
+} // namespace ac::llama

--- a/code/ac/llama/LoraAdapter.hpp
+++ b/code/ac/llama/LoraAdapter.hpp
@@ -17,7 +17,7 @@ public:
 
     llama_lora_adapter* adapter() const noexcept { return m_adapter.get(); }
     float scale() const noexcept { return m_scale; }
-    std::string_view path() const noexcept { return m_path; }
+    const std::string& path() const noexcept { return m_path; }
 
 private:
     astl::c_unique_ptr<llama_lora_adapter> m_adapter;

--- a/code/ac/llama/LoraAdapter.hpp
+++ b/code/ac/llama/LoraAdapter.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) Alpaca Core
+// SPDX-License-Identifier: MIT
+//
+#pragma once
+#include "export.h"
+#include <astl/mem_ext.hpp>
+#include <string>
+
+struct llama_lora_adapter;
+
+namespace ac::llama {
+class Model;
+
+class AC_LLAMA_EXPORT LoraAdapter {
+public:
+    LoraAdapter(Model& model, std::string path, float scale = 1.0f);
+
+    llama_lora_adapter* adapter() const noexcept { return m_adapter.get(); }
+    float scale() const noexcept { return m_scale; }
+    std::string_view path() const noexcept { return m_path; }
+
+private:
+    astl::c_unique_ptr<llama_lora_adapter> m_adapter;
+    float m_scale;
+    std::string m_path;
+};
+
+} // namespace ac::llama

--- a/code/ac/llama/Model.cpp
+++ b/code/ac/llama/Model.cpp
@@ -35,8 +35,8 @@ llama_model_params llamaFromModelParams(const Model::Params& params, ModelLoadPr
 
 
 Model::Model(std::shared_ptr<llama_model> lmodel, Params params)
-    : m_lmodel(std::move(lmodel))
-    , m_params(astl::move(params))
+    : m_params(astl::move(params))
+    , m_lmodel(std::move(lmodel))
 {}
 
 Model::~Model() = default;

--- a/code/ac/llama/Model.cpp
+++ b/code/ac/llama/Model.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 //
 #include "Model.hpp"
+#include "LoraAdapter.hpp"
 #include <llama.h>
 #include <astl/move.hpp>
 #include <stdexcept>
@@ -77,16 +78,6 @@ std::string Model::getChatTemplateId() const {
     }
 
     return std::string(tplBuf.get(), len);
-}
-
-LoraAdapter::LoraAdapter(Model& model, std::string path, float scale)
-    : m_adapter(llama_lora_adapter_init(model.lmodel(), path.c_str()), llama_lora_adapter_free)
-    , m_scale(scale)
-    , m_path(std::move(path))
-{
-    if (!m_adapter) {
-        throw std::runtime_error("Failed to initialize LORA adapter from " + m_path);
-    }
 }
 
 std::shared_ptr<llama_model> Model::ModelRegistry::loadModel(

--- a/code/ac/llama/Model.cpp
+++ b/code/ac/llama/Model.cpp
@@ -34,7 +34,7 @@ llama_model_params llamaFromModelParams(const Model::Params& params, ModelLoadPr
 } // namespace
 
 
-Model::Model(const char* pathToGguf, std::vector<std::string> loras, ModelLoadProgressCb loadProgressCb, Params params)
+Model::Model(const char* pathToGguf, std::span<std::string> loras, ModelLoadProgressCb loadProgressCb, Params params)
     : m_params(astl::move(params))
 {
     m_lmodel = ModelRegistry::getInstance().loadModel(pathToGguf, std::move(loadProgressCb), m_params);

--- a/code/ac/llama/Model.cpp
+++ b/code/ac/llama/Model.cpp
@@ -34,19 +34,10 @@ llama_model_params llamaFromModelParams(const Model::Params& params, ModelLoadPr
 } // namespace
 
 
-Model::Model(const char* pathToGguf, std::span<std::string> loras, ModelLoadProgressCb loadProgressCb, Params params)
-    : m_params(astl::move(params))
-{
-    m_lmodel = ModelRegistry::getInstance().loadModel(pathToGguf, std::move(loadProgressCb), m_params);
-    if (!m_lmodel) {
-        throw std::runtime_error("Failed to load model");
-    }
-
-    for(auto& loraPath: loras) {
-        auto lora = ModelRegistry::getInstance().loadLora(this, loraPath);
-        m_loras.push_back(lora);
-    }
-}
+Model::Model(std::shared_ptr<llama_model> lmodel, Params params)
+    : m_lmodel(std::move(lmodel))
+    , m_params(astl::move(params))
+{}
 
 Model::~Model() = default;
 

--- a/code/ac/llama/Model.cpp
+++ b/code/ac/llama/Model.cpp
@@ -107,6 +107,10 @@ std::shared_ptr<LoraAdapter> Model::ModelRegistry::loadLora(Model* model, const 
 
     auto loadedLoras = m_loras[model->lmodel()];
 
+    loadedLoras.erase(std::find_if(loadedLoras.begin(), loadedLoras.end(), [&](const auto& lora) {
+        return lora.expired();
+    }), loadedLoras.end());
+
     for (auto& lora : loadedLoras) {
         if (!lora.expired() && lora.lock()->path() == loraPath) {
             return lora.lock();

--- a/code/ac/llama/Model.cpp
+++ b/code/ac/llama/Model.cpp
@@ -82,6 +82,12 @@ std::shared_ptr<llama_model> ModelRegistry::loadModel(
     const std::string& gguf,
     ModelLoadProgressCb pcb,
     Model::Params params) {
+
+    // clean up expired models
+    m_models.erase(std::find_if(m_models.begin(), m_models.end(), [&](const auto& m) {
+        return m.second.expired();
+    }), m_models.end());
+
     std::shared_ptr<llama_model> model = nullptr;
     auto key = ModelKey{gguf, params};
     for (auto& m: m_models) {

--- a/code/ac/llama/Model.hpp
+++ b/code/ac/llama/Model.hpp
@@ -26,7 +26,7 @@ public:
         bool prefixInputsWithBos = false; // add bos token to interactive inputs (#13)
     };
 
-    Model(const char* pathToGguf, std::span<std::string> loras, ModelLoadProgressCb loadProgressCb, Params params);
+    Model(std::shared_ptr<llama_model> model, Params params);
     ~Model();
 
     const Params& params() const noexcept { return m_params; }
@@ -57,7 +57,7 @@ private:
     Vocab m_vocab{*this};
 };
 
-class ModelRegistry {
+class AC_LLAMA_EXPORT ModelRegistry {
 public:
     static ModelRegistry& getInstance() {
         static ModelRegistry instance;

--- a/code/ac/llama/Model.hpp
+++ b/code/ac/llama/Model.hpp
@@ -24,6 +24,12 @@ public:
         bool gpu = true; // try to load data on gpu
         bool vocabOnly = false; // do not load model, only vocab
         bool prefixInputsWithBos = false; // add bos token to interactive inputs (#13)
+
+        bool operator==(const Params& other) const noexcept {
+            return gpu == other.gpu
+                    && vocabOnly == other.vocabOnly
+                    && prefixInputsWithBos == other.prefixInputsWithBos;
+        }
     };
 
     Model(std::shared_ptr<llama_model> model, Params params);
@@ -78,9 +84,7 @@ private:
 
         bool operator==(const ModelKey& other) const noexcept {
             return gguf == other.gguf
-                    && params.gpu == other.params.gpu
-                    && params.prefixInputsWithBos == other.params.prefixInputsWithBos
-                    && params.vocabOnly == other.params.vocabOnly;
+                    && params == other.params;
         }
     };
 

--- a/code/ac/llama/Model.hpp
+++ b/code/ac/llama/Model.hpp
@@ -73,18 +73,4 @@ private:
     static ModelRegistry s_modelRegistry;
 };
 
-class AC_LLAMA_EXPORT LoraAdapter {
-public:
-    LoraAdapter(Model& model, std::string path, float scale = 1.0f);
-
-    llama_lora_adapter* adapter() const noexcept { return m_adapter.get(); }
-    float scale() const noexcept { return m_scale; }
-    std::string_view path() const noexcept { return m_path; }
-
-private:
-    astl::c_unique_ptr<llama_lora_adapter> m_adapter;
-    float m_scale;
-    std::string m_path;
-};
-
 } // namespace ac::llama

--- a/code/ac/llama/Model.hpp
+++ b/code/ac/llama/Model.hpp
@@ -26,7 +26,7 @@ public:
         bool prefixInputsWithBos = false; // add bos token to interactive inputs (#13)
     };
 
-    Model(const char* pathToGguf, std::vector<std::string> loras, ModelLoadProgressCb loadProgressCb, Params params);
+    Model(const char* pathToGguf, std::span<std::string> loras, ModelLoadProgressCb loadProgressCb, Params params);
     ~Model();
 
     const Params& params() const noexcept { return m_params; }

--- a/example/e-basic.cpp
+++ b/example/e-basic.cpp
@@ -45,7 +45,7 @@ int main() try {
         }
         return true;
     };
-    ac::llama::Model model(modelGguf.c_str(), modelLoadProgressCallback, modelParams);
+    ac::llama::Model model(modelGguf.c_str(), {}, modelLoadProgressCallback, modelParams);
 
 
     // create inference instance

--- a/example/e-basic.cpp
+++ b/example/e-basic.cpp
@@ -45,7 +45,8 @@ int main() try {
         }
         return true;
     };
-    ac::llama::Model model(modelGguf.c_str(), {}, modelLoadProgressCallback, modelParams);
+    auto lmodel = ac::llama::ModelRegistry::getInstance().loadModel(modelGguf, modelLoadProgressCallback, modelParams);
+    ac::llama::Model model(lmodel, modelParams);
 
 
     // create inference instance

--- a/example/e-gui.cpp
+++ b/example/e-gui.cpp
@@ -61,7 +61,7 @@ public:
     class State {
     public:
         State(const std::string& ggufPath, const ac::llama::Model::Params& modelParams)
-            : m_model(ggufPath.c_str(), {}, printModelLoadProgress, modelParams)
+            : m_model(ac::llama::ModelRegistry::getInstance().loadModel(ggufPath.c_str(), printModelLoadProgress, modelParams), modelParams)
         {}
 
         class Instance {

--- a/example/e-gui.cpp
+++ b/example/e-gui.cpp
@@ -48,6 +48,8 @@ void printModelLoadProgress(float progress) {
     }
 };
 
+ac::llama::ModelRegistry g_modelRegistry;
+
 // unloadable model
 class UModel {
 public:
@@ -61,7 +63,7 @@ public:
     class State {
     public:
         State(const std::string& ggufPath, const ac::llama::Model::Params& modelParams)
-            : m_model(ggufPath.c_str(), printModelLoadProgress, modelParams)
+            : m_model(g_modelRegistry.loadModel(ggufPath.c_str(), {}, printModelLoadProgress, modelParams))
         {}
 
         class Instance {

--- a/example/e-gui.cpp
+++ b/example/e-gui.cpp
@@ -48,8 +48,6 @@ void printModelLoadProgress(float progress) {
     }
 };
 
-ac::llama::ModelRegistry g_modelRegistry;
-
 // unloadable model
 class UModel {
 public:
@@ -63,7 +61,7 @@ public:
     class State {
     public:
         State(const std::string& ggufPath, const ac::llama::Model::Params& modelParams)
-            : m_model(g_modelRegistry.loadModel(ggufPath.c_str(), {}, printModelLoadProgress, modelParams))
+            : m_model(ggufPath.c_str(), {}, printModelLoadProgress, modelParams)
         {}
 
         class Instance {

--- a/test/t-integration.cpp
+++ b/test/t-integration.cpp
@@ -22,7 +22,9 @@ GlobalFixture globalFixture;
 const char* Model_117m_q6_k = AC_TEST_DATA_LLAMA_DIR "/gpt2-117m-q6_k.gguf";
 
 TEST_CASE("vocab only") {
-    ac::llama::Model model(Model_117m_q6_k, {}, {}, { .vocabOnly = true });
+    ac::llama::Model::Params iParams = { .vocabOnly = true };
+    auto lmodel = ac::llama::ModelRegistry::getInstance().loadModel(Model_117m_q6_k, {}, iParams);
+    ac::llama::Model model(lmodel, iParams);
     CHECK(!!model.lmodel());
 
     auto& params = model.params();
@@ -40,7 +42,9 @@ TEST_CASE("vocab only") {
 }
 
 TEST_CASE("inference") {
-    ac::llama::Model model(Model_117m_q6_k, {}, {}, {});
+    ac::llama::Model::Params iParams = {};
+    auto lmodel = ac::llama::ModelRegistry::getInstance().loadModel(Model_117m_q6_k, {}, iParams);
+    ac::llama::Model model(lmodel, iParams);
     CHECK(!!model.lmodel());
 
     auto& params = model.params();

--- a/test/t-integration.cpp
+++ b/test/t-integration.cpp
@@ -87,7 +87,9 @@ TEST_CASE("inference") {
 }
 
 TEST_CASE("session states") {
-    ac::llama::Model model(Model_117m_q6_k, {}, {});
+    ac::llama::Model::Params iParams = {};
+    auto lmodel = ac::llama::ModelRegistry::getInstance().loadModel(Model_117m_q6_k, {}, iParams);
+    ac::llama::Model model(lmodel, iParams);
     CHECK(!!model.lmodel());
 
     auto& params = model.params();
@@ -137,7 +139,9 @@ TEST_CASE("session states") {
 }
 
 TEST_CASE("control_vector") {
-    ac::llama::Model model(Model_117m_q6_k, {}, {});
+    ac::llama::Model::Params iParams = {};
+    auto lmodel = ac::llama::ModelRegistry::getInstance().loadModel(Model_117m_q6_k, {}, iParams);
+    ac::llama::Model model(lmodel, iParams);
     CHECK(!!model.lmodel());
 
     auto& params = model.params();

--- a/test/t-integration.cpp
+++ b/test/t-integration.cpp
@@ -15,6 +15,8 @@ struct GlobalFixture {
     GlobalFixture() {
         ac::llama::initLibrary();
     }
+
+    ac::llama::ModelRegistry modelRegistry;
 };
 
 GlobalFixture globalFixture;
@@ -22,7 +24,8 @@ GlobalFixture globalFixture;
 const char* Model_117m_q6_k = AC_TEST_DATA_LLAMA_DIR "/gpt2-117m-q6_k.gguf";
 
 TEST_CASE("vocab only") {
-    ac::llama::Model model(Model_117m_q6_k, {}, { .vocabOnly = true });
+    ac::llama::ModelRegistry mRegistry;
+    ac::llama::Model model = mRegistry.loadModel(Model_117m_q6_k, {}, {}, { .vocabOnly = true });
     CHECK(!!model.lmodel());
 
     auto& params = model.params();
@@ -40,7 +43,8 @@ TEST_CASE("vocab only") {
 }
 
 TEST_CASE("inference") {
-    ac::llama::Model model(Model_117m_q6_k, {}, {});
+    ac::llama::ModelRegistry mRegistry;
+    ac::llama::Model model = mRegistry.loadModel(Model_117m_q6_k, {}, {}, {});
     CHECK(!!model.lmodel());
 
     auto& params = model.params();

--- a/test/t-integration.cpp
+++ b/test/t-integration.cpp
@@ -15,8 +15,6 @@ struct GlobalFixture {
     GlobalFixture() {
         ac::llama::initLibrary();
     }
-
-    ac::llama::ModelRegistry modelRegistry;
 };
 
 GlobalFixture globalFixture;
@@ -24,8 +22,7 @@ GlobalFixture globalFixture;
 const char* Model_117m_q6_k = AC_TEST_DATA_LLAMA_DIR "/gpt2-117m-q6_k.gguf";
 
 TEST_CASE("vocab only") {
-    ac::llama::ModelRegistry mRegistry;
-    ac::llama::Model model = mRegistry.loadModel(Model_117m_q6_k, {}, {}, { .vocabOnly = true });
+    ac::llama::Model model(Model_117m_q6_k, {}, {}, { .vocabOnly = true });
     CHECK(!!model.lmodel());
 
     auto& params = model.params();
@@ -43,8 +40,7 @@ TEST_CASE("vocab only") {
 }
 
 TEST_CASE("inference") {
-    ac::llama::ModelRegistry mRegistry;
-    ac::llama::Model model = mRegistry.loadModel(Model_117m_q6_k, {}, {}, {});
+    ac::llama::Model model(Model_117m_q6_k, {}, {}, {});
     CHECK(!!model.lmodel());
 
     auto& params = model.params();


### PR DESCRIPTION
Added LoRa support to the AC Model.

LoRas' are distinguished from the model as assets which have `lora:` in their tags.

In our examples/test we use `gpt2` and I couldn't find appropriate LoRa for that model. All I've found are embedded in the model itself. The tests are made on my PC using llama3, that's why I haven't added tests yet.

closes #4