### PR TITLE
Allow sampler modifications

### DIFF
--- a/code/ac/llama/Instance.cpp
+++ b/code/ac/llama/Instance.cpp
@@ -34,9 +34,9 @@ llama_context_params llamaFromInstanceInitParams(const Instance::InitParams& par
 
 Instance::Instance(Model& model, InitParams params)
     : m_model(model)
-    , m_sampler(model, {
+    , m_sampler(new Sampler(model, {
         .grammar = params.grammar,
-    })
+    }))
     , m_lctx(llama_init_from_model(model.lmodel(), llamaFromInstanceInitParams(params)), llama_free)
 {
     if (!m_lctx) {

--- a/code/ac/llama/Instance.hpp
+++ b/code/ac/llama/Instance.hpp
@@ -44,6 +44,7 @@ public:
     Sampler& sampler() noexcept { return *m_sampler; }
 
     // Change sampler settings by resetting it
+    // warning: this will clear any previous sampler state
     void resetSampler(const Sampler::Params& params) {
         m_sampler.reset(new Sampler(m_model, params));
     }

--- a/code/ac/llama/Instance.hpp
+++ b/code/ac/llama/Instance.hpp
@@ -40,11 +40,17 @@ public:
     void stopSession() noexcept;
 
     const Model& model() const noexcept { return m_model; }
-    Sampler& sampler() noexcept { return m_sampler; }
+
+    Sampler& sampler() noexcept { return *m_sampler; }
+
+    // Change sampler settings by resetting it
+    void resetSampler(const Sampler::Params& params) {
+        m_sampler.reset(new Sampler(m_model, params));
+    }
 
 private:
     Model& m_model;
-    Sampler m_sampler;
+    std::unique_ptr<Sampler> m_sampler;
     astl::c_unique_ptr<llama_context> m_lctx;
     std::optional<Session> m_session;
 };

--- a/code/ac/llama/Model.cpp
+++ b/code/ac/llama/Model.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<llama_model> ModelRegistry::loadModel(
     }
 
     if (!model) {
-        model = std::shared_ptr<llama_model>(llama_load_model_from_file(gguf.c_str(), llamaFromModelParams(params, pcb)), llama_free_model);
+        model = std::shared_ptr<llama_model>(llama_model_load_from_file(gguf.c_str(), llamaFromModelParams(params, pcb)), llama_model_free);
         m_models.push_back({key, model});
     }
 


### PR DESCRIPTION
In the beginning I thought that we should be able to tweak each type of sampler, but that might not an easy task since there e since there are no methods for sampler modification.

I checked how they do it in `llama.cpp` server and it seems like they are resetting the sampler which is what we're doing right now.

closes #23