### PR TITLE
Expose grammar sampling option

### DIFF
--- a/code/ac/llama/Instance.cpp
+++ b/code/ac/llama/Instance.cpp
@@ -34,7 +34,9 @@ llama_context_params llamaFromInstanceInitParams(const Instance::InitParams& par
 
 Instance::Instance(Model& model, InitParams params)
     : m_model(model)
-    , m_sampler(model, {})
+    , m_sampler(model, {
+        .grammar = params.grammar,
+    })
     , m_lctx(llama_init_from_model(model.lmodel(), llamaFromInstanceInitParams(params)), llama_free)
 {
     if (!m_lctx) {

--- a/code/ac/llama/Instance.hpp
+++ b/code/ac/llama/Instance.hpp
@@ -23,6 +23,7 @@ public:
         uint32_t batchSize = 2048; // logical batch size for prompt processing (may be silently truncated to ctxSize)
         uint32_t ubatchSize = 512; // physical batch size for prompt processing (0 = batchSize)
         bool flashAttn = false; // enable flash attention
+        std::string grammar; // BNF-styled grammar
     };
 
     explicit Instance(Model& model, InitParams params);


### PR DESCRIPTION
Example for grammars we can see in llama.cpp repository [here](https://github.com/ggerganov/llama.cpp/tree/master/grammars). 

I didn't add an example since the model we use 117M doesn't respond that good and it just makes the usage even harder. That's why I've added some tests to see that the grammars are taken into account.

closes #8 